### PR TITLE
fix multiple many-to-one relationships to a table

### DIFF
--- a/internal/gen-go-model/gen/generator.go
+++ b/internal/gen-go-model/gen/generator.go
@@ -445,7 +445,6 @@ func (g *generator) getFullRelationShips() (toColumnNameToRelationships map[stri
 			// support inline relationship
 			fullColumnID := getFullColumnName(table.Name, column.Name)
 			toRelationships := toColumnNameToRelationships[fullColumnID]
-			fromRelationships := fromColumnNameToRelationships[fullColumnID]
 			fromRefTagStr, found := column.Annotations[GoTagFromRefAnnotation]
 			fromTags := structtag.Tags{}
 			if found {
@@ -475,6 +474,7 @@ func (g *generator) getFullRelationShips() (toColumnNameToRelationships map[stri
 				})
 
 				reverseRefType := reverseRefType(refType)
+				fromRelationships := fromColumnNameToRelationships[column.Settings.Ref.To]
 				fromRelationships = append(fromRelationships, core.Relationship{
 					From: column.Settings.Ref.To,
 					To:   fullColumnID,


### PR DESCRIPTION
# Issue
We have a bug when two tables have many-to-one relationship to another table.

```
table users {
  id bigint [pk, increment]
}

table items {
  id bigint [pk, increment]
  user_id bigint [ref: > users.id, not null]
}

table products {
  id bigint [pk, increment]
  user_id bigint [ref: > users.id, not null]
}
```

With the above example, dbml-go generates the `User` struct with this result:
```go
type User struct {
	ID       int64     `json:"id" mapstructure:"id"`
	Products []Product `gorm:"foreignkey:user_id"`
}
```

The expected result is
```go
type User struct {
	ID       int64     `json:"id" mapstructure:"id"`
	Items    []Item    `gorm:"foreignkey:user_id"`
	Products []Product `gorm:"foreignkey:user_id"`
}
```

This PR resolve the above issue.