### PR TITLE
Bugfix/field naming

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/dave/jennifer v1.4.0
 	github.com/fatih/structtag v1.2.0 // indirect
+	github.com/gertd/go-pluralize v0.2.1 // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gertd/go-pluralize v0.2.1 h1:M3uASbVjMnTsPb0PNqg+E/24Vwigyo/tvyMTtAlLgiA=
+github.com/gertd/go-pluralize v0.2.1/go.mod h1:rbYaKDbsXxmRfr8uygAEKhOWsjyrrqrkHVpZvoOp8zk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=

--- a/internal/gen-go-model/gen/generator.go
+++ b/internal/gen-go-model/gen/generator.go
@@ -110,7 +110,7 @@ type fieldDefinition struct {
 
 func leftOf(str string, strToSplit string) string {
 	idx := strings.LastIndex(str, strToSplit)
-	if idx == 0 {
+	if idx == -1 {
 		return ""
 	}
 	return str[:idx]

--- a/internal/gen-go-model/gen/generator.go
+++ b/internal/gen-go-model/gen/generator.go
@@ -445,6 +445,7 @@ func (g *generator) getFullRelationShips() (toColumnNameToRelationships map[stri
 			// support inline relationship
 			fullColumnID := getFullColumnName(table.Name, column.Name)
 			toRelationships := toColumnNameToRelationships[fullColumnID]
+			fromRelationships := fromColumnNameToRelationships[fullColumnID]
 			fromRefTagStr, found := column.Annotations[GoTagFromRefAnnotation]
 			fromTags := structtag.Tags{}
 			if found {
@@ -474,7 +475,6 @@ func (g *generator) getFullRelationShips() (toColumnNameToRelationships map[stri
 				})
 
 				reverseRefType := reverseRefType(refType)
-				fromRelationships := fromColumnNameToRelationships[column.Settings.Ref.To]
 				fromRelationships = append(fromRelationships, core.Relationship{
 					From: column.Settings.Ref.To,
 					To:   fullColumnID,

--- a/internal/gen-go-model/genutil/strcase.go
+++ b/internal/gen-go-model/genutil/strcase.go
@@ -71,7 +71,7 @@ func Initialism(s string) string {
 			w = i + 1
 			buf.WriteRune('_')
 		}
-		if unicode.IsLower(runes[i]) && (i == len(runes)-1 || runes[i+1] == '_' || unicode.IsUpper(runes[i+1])) {
+		if (unicode.IsLower(runes[i]) || unicode.IsNumber(runes[i])) && (i == len(runes)-1 || runes[i+1] == '_' || unicode.IsUpper(runes[i+1])) {
 			word := string(runes[w : i+1])
 			if u := strings.ToUpper(word); commonInitialisms[u] && unicode.IsUpper(runes[w]) {
 				buf.WriteString(u)

--- a/test.dbml
+++ b/test.dbml
@@ -1,16 +1,21 @@
-Table casbin_rule {
+Table cities {
   id bigint [pk, increment]
-  ptype varchar(100) [not null, default: ``]
-  v0 varchar(100) [not null, default: ``]
-  v1 varchar(100) [not null, default: ``]
-  v2 varchar(100) [not null, default: ``]
-  v3 varchar(100) [not null, default: ``]
-  v4 varchar(100) [not null, default: ``]
-  v5 varchar(100) [not null, default: ``]
-  v6 varchar(25) [not null, default: ``]
-  v7 varchar(25) [not null, default: ``]
+  name varchar(255)
+  code varchar(255) [not null, unique]
+  created_at datetime [not null, default: `CURRENT_TIMESTAMP`]
+  updated_at datetime [not null, default: `CURRENT_TIMESTAMP`]
+}
+
+Table districts {
+  id bigint [pk, increment]
+  code varchar(255) [not null, unique]
+  name varchar(255)
+  city_id bigint [ref: > cities.id, not null]
+  my_city_id bigint [ref: > cities.id, not null]
+  created_at datetime [not null, default: `CURRENT_TIMESTAMP`]
+  updated_at datetime [not null, default: `CURRENT_TIMESTAMP`]
 
   Indexes {
-    (ptype, v0, v1, v2, v3, v4, v5, v6, v7) [unique, name: 'idx_casbin_rules']
+    city_id [name: 'idx_districts_city_id']
   }
 }


### PR DESCRIPTION
Fix 2 errors:
Error 1: When table is
```
Table districts {
  id bigint [pk, increment]
  code varchar(255) [not null, unique]
  name varchar(255)
  city_id bigint [ref: > cities.id, not null]
  my_city_id bigint [ref: > cities.id, not null]
  created_at datetime [not null, default: `CURRENT_TIMESTAMP`]
  updated_at datetime [not null, default: `CURRENT_TIMESTAMP`]

  Indexes {
    city_id [name: 'idx_districts_city_id']
  }
}

```
then the generated model contains 2 fields of Districts
After fix result will be:
```
// City is generated type for table 'cities'
type City struct {
	ID          int64      `json:"id" mapstructure:"id"`
	Districts   []District `gorm:"foreignkey:city_id"`
	MyDistricts []District `gorm:"foreignkey:my_city_id"`
	Name        *string    `json:"name" mapstructure:"name"`
	Code        string     `json:"code" mapstructure:"code"`
	CreatedAt   time.Time  `json:"created_at" mapstructure:"created_at"`
	UpdatedAt   time.Time  `json:"updated_at" mapstructure:"updated_at"`
}
```

Error 2:
Generate column search_text_v1 to SearchText field, so if table contains 2 fields of search_text_v1, and search_text_v2, the generated model will contain 2 fields SearchText.
After fix: search_text_v1 will generate SearchTextV1 field, search_text_v2 will generate SearchTextV2 field.